### PR TITLE
Melhora validation_instance.rb

### DIFF
--- a/lib/vagas_commons/validation/validation_instance.rb
+++ b/lib/vagas_commons/validation/validation_instance.rb
@@ -2,8 +2,26 @@
 
 module VagasCommons::ValidationInstance
   def get_validation_instance(instance)
-    raise 'Invalid Validation Schema' if instance.call.superclass.to_s != 'Dry::Validation::Contract'
+    get_instance = set_validation_instance(instance)
+    raise 'Invalid Validation Schema' if get_instance.nil?
 
-    instance.call.new
+    get_instance
+  end
+
+  def set_validation_instance(instance)
+    begin
+      # se responder ao método, provavelmente é um esquema de validação
+      if instance.call.respond_to?(:ancestors) && instance.call.ancestors.include?(Dry::Validation::Contract)
+        return instance.call.new
+      end
+
+      # se não responder ao método, provavelmente é um contrato de validação
+      if instance.call.respond_to?(:ancestors) == false && instance.call.class.ancestors.include?(Dry::Validation::Contract)
+        return instance.call
+      end
+      nil
+    rescue RuntimeError, NoMethodError, StandardError
+      raise 'Invalid Validation Schema'
+    end
   end
 end


### PR DESCRIPTION
**Motivação**
Em alguns casos, o define_validation pode receber um esquema de validação. Em outros, ele pode receber um contrato de validação. Apesar de parecidos, suas implementações tem diferenças no sentido de se poder definir regras personalizadas, etc. Agora validamos o parâmetro recebido para determinar como a instância será devolvida.