### PR TITLE
Update configurable dsl api calls

### DIFF
--- a/lib/vagas_commons.rb
+++ b/lib/vagas_commons.rb
@@ -15,16 +15,15 @@ require 'vagas_commons/serializers' if defined?(ActiveModel::Serializer)
 module VagasCommons
   extend Dry::Configurable
 
-  setting :logger, Logger.new(STDOUT)
+  setting :logger, default: Logger.new($stdout)
   setting :request do
-    setting :user_agent, 'gem VAGAS Commons'
+    setting :user_agent, default: 'gem VAGAS Commons'
   end
   setting :requests do
-    setting :max_concurrent, 10
+    setting :max_concurrent, default: 10
   end
 
   def self.logger
     config.logger
-    
   end
 end


### PR DESCRIPTION
Ao atualizar o projeto _pesquisa_profissionais_service_ surgiram alguns erros, e verificando a _gem_ **vagas_commons** e o repositório referente a ela, vi que estavam faltando alguns detalhes no arquivo _lib/vagas_commons.rb_, e por isso foi necessária essa pequena modificação para que funcionasse corretamente.